### PR TITLE
Fix #53: skip zero units for all time intervals in Float#seconds and add tests (follow-up)

### DIFF
--- a/lib/tago.rb
+++ b/lib/tago.rb
@@ -19,24 +19,26 @@ class Float
     elsif s < 1
       format('%dms', s * 1000)
     elsif s < 10
-      ms = format('%03d', s * 1000 % 1000)
-      if ms == '000'
-        format('%ds', s)
-      else
-        format('%<sec>ds%<msec>sms', sec: s, msec: ms)
-      end
+      ms = (s * 1000 % 1000).to_i
+      ms.zero? ? format('%ds', s) : format('%<s>ds%<ms>dms', s:, ms:)
     elsif s < 100
       format('%ds', s)
     elsif s < 60 * 60
-      format('%<mins>dm%<secs>ds', mins: s / 60, secs: s % 60)
+      mins = (s / 60).to_i
+      secs = (s % 60).to_i
+      secs.zero? ? format('%dm', mins) : format('%<mins>dm%<secs>ds', mins:, secs:)
     elsif s < 24 * 60 * 60
-      format('%<hours>dh%<mins>dm', hours: s / (60 * 60), mins: (s % (60 * 60)) / 60)
+      hours = (s / (60 * 60)).to_i
+      mins = ((s % (60 * 60)) / 60).to_i
+      mins.zero? ? format('%dh', hours) : format('%<hours>dh%<mins>dm', hours:, mins:)
     elsif s < 7 * 24 * 60 * 60
-      format('%<days>dd%<hours>dh', days: s / (24 * 60 * 60), hours: (s % (24 * 60 * 60)) / (60 * 60))
+      days = (s / (24 * 60 * 60)).to_i
+      hours = ((s % (24 * 60 * 60)) / (60 * 60)).to_i
+      hours.zero? ? format('%dd', days) : format('%<days>dd%<hours>dh', days:, hours:)
     else
-      weeks = s / (7 * 24 * 60 * 60)
-      days = s / (24 * 60 * 60) % 7
-      days.to_i.zero? ? format('%dw', weeks) : format('%<weeks>dw%<days>dd', weeks:, days:)
+      weeks = (s / (7 * 24 * 60 * 60)).to_i
+      days = (s / (24 * 60 * 60) % 7).to_i
+      days.zero? ? format('%dw', weeks) : format('%<weeks>dw%<days>dd', weeks:, days:)
     end
   end
 end

--- a/test/test_tago.rb
+++ b/test/test_tago.rb
@@ -14,32 +14,47 @@ class TestTago < Minitest::Test
   def test_simple_printing
     t = Time.now
     assert_equal('14ms', (t - 0.014).ago(t))
-    assert_equal('1s', (t - 1).ago(t))
     assert_equal('1s350ms', (t - 1.35).ago(t))
+    assert_equal('2s', (t - 2).ago(t))
     assert_equal('67s', (t - 67).ago(t))
     assert_equal('4m5s', (t - 245).ago(t))
+    assert_equal('6m', (t - 360).ago(t))
     assert_equal('13h18m', (t - (13.3 * 60 * 60)).ago(t))
-    assert_equal('5d0h', (t - (5 * 24 * 60 * 60)).ago(t))
+    assert_equal('16h', (t - (16 * 60 * 60)).ago(t))
     assert_equal('5d7h', (t - (5.3 * 24 * 60 * 60)).ago(t))
-    assert_equal('22w1d', (t - (155 * 24 * 60 * 60)).ago(t))
+    assert_equal('6d', (t - (6 * 24 * 60 * 60)).ago(t))
+    assert_equal('2w1d', (t - (15 * 24 * 60 * 60)).ago(t))
+    assert_equal('10w', (t - (70 * 24 * 60 * 60)).ago(t))
   end
 
   def test_inverse
     t = Time.now
     assert_equal('14ms', (t + 0.014).ago(t))
     assert_equal('1s', (t + 1).ago(t))
+    assert_equal('3s250ms', (t + 3.25).ago(t))
     assert_equal('67s', (t + 67).ago(t))
-    assert_equal('13h0m', (t + (13 * 60 * 60)).ago(t))
-    assert_equal('5d0h', (t + (5 * 24 * 60 * 60)).ago(t))
+    assert_equal('2m', (t + 120).ago(t))
+    assert_equal('4m51s', (t + 291).ago(t))
+    assert_equal('13h', (t + (13 * 60 * 60)).ago(t))
+    assert_equal('19h42m', (t + (19.7 * 60 * 60)).ago(t))
+    assert_equal('5d', (t + (5 * 24 * 60 * 60)).ago(t))
+    assert_equal('6d23h', (t + (6 * 24 * 60 * 60) + (23 * 60 * 60)).ago(t))
+    assert_equal('8w', (t + (56 * 24 * 60 * 60)).ago(t))
     assert_equal('22w1d', (t + (155 * 24 * 60 * 60)).ago(t))
   end
 
   def test_float_to_seconds
     assert_equal('18ms', 0.018.seconds)
     assert_equal('2s330ms', 2.33.seconds)
+    assert_equal('4s', 4.0.seconds)
     assert_equal('69s', 69.17.seconds)
+    assert_equal('3m4s', 184.2.seconds)
+    assert_equal('7m', 420.0.seconds)
     assert_equal('12h6m', (12.1 * 60 * 60).seconds)
+    assert_equal('20h', (20.001 * 60 * 60).seconds)
     assert_equal('5d7h', (5.3 * 24 * 60 * 60).seconds)
+    assert_equal('6d', (6.0 * 24 * 60 * 60).seconds)
+    assert_equal('2w1d', (15.5 * 24 * 60 * 60).seconds)
     assert_equal('19w', ((132.6 * 24 * 60 * 60) + (23 * 60 * 60)).seconds)
   end
 end


### PR DESCRIPTION
This is a follow-up to the [previous fix](https://github.com/yegor256/tago/issues/53). It extends zero-unit skipping to all time intervals (days, hours, minutes,) and adds tests for both Float#seconds and Time#ago to ensure proper formatting. 