### PR TITLE
Fix #70: add :round option to Float#seconds method

### DIFF
--- a/lib/tago.rb
+++ b/lib/tago.rb
@@ -11,7 +11,7 @@ require 'time'
 # Copyright:: Copyright (c) 2024-2025 Yegor Bugayenko
 # License:: MIT
 class Float
-  def seconds
+  def seconds(format = nil)
     s = self
     s = -s if s.negative?
     if s < 0.001
@@ -20,25 +20,45 @@ class Float
       format('%dms', s * 1000)
     elsif s < 10
       ms = (s * 1000 % 1000).to_i
-      ms.zero? ? format('%ds', s) : format('%<s>ds%<ms>dms', s:, ms:)
+      if format == :round || ms.zero?
+        format('%ds', s)
+      else
+        format('%<s>ds%<ms>dms', s:, ms:)
+      end
     elsif s < 100
       format('%ds', s)
     elsif s < 60 * 60
       mins = (s / 60).to_i
       secs = (s % 60).to_i
-      secs.zero? ? format('%dm', mins) : format('%<mins>dm%<secs>ds', mins:, secs:)
+      if format == :round || secs.zero?
+        format('%dm', mins)
+      else
+        format('%<mins>dm%<secs>ds', mins:, secs:)
+      end
     elsif s < 24 * 60 * 60
       hours = (s / (60 * 60)).to_i
       mins = ((s % (60 * 60)) / 60).to_i
-      mins.zero? ? format('%dh', hours) : format('%<hours>dh%<mins>dm', hours:, mins:)
+      if format == :round || mins.zero?
+        format('%dh', hours)
+      else
+        format('%<hours>dh%<mins>dm', hours:, mins:)
+      end
     elsif s < 7 * 24 * 60 * 60
       days = (s / (24 * 60 * 60)).to_i
       hours = ((s % (24 * 60 * 60)) / (60 * 60)).to_i
-      hours.zero? ? format('%dd', days) : format('%<days>dd%<hours>dh', days:, hours:)
+      if format == :round || hours.zero?
+        format('%dd', days)
+      else
+        format('%<days>dd%<hours>dh', days:, hours:)
+      end
     else
       weeks = (s / (7 * 24 * 60 * 60)).to_i
       days = (s / (24 * 60 * 60) % 7).to_i
-      days.zero? ? format('%dw', weeks) : format('%<weeks>dw%<days>dd', weeks:, days:)
+      if format == :round || days.zero?
+        format('%dw', weeks)
+      else
+        format('%<weeks>dw%<days>dd', weeks:, days:)
+      end
     end
   end
 end

--- a/test/test_tago.rb
+++ b/test/test_tago.rb
@@ -57,4 +57,37 @@ class TestTago < Minitest::Test
     assert_equal('2w1d', (15.5 * 24 * 60 * 60).seconds)
     assert_equal('19w', ((132.6 * 24 * 60 * 60) + (23 * 60 * 60)).seconds)
   end
+
+  def test_round_formatting
+    # Milliseconds range (< 1s)
+    assert_equal('500ms', 0.5.seconds(:round))
+
+    # Seconds with milliseconds (< 10s)
+    assert_equal('9s', 9.444.seconds(:round))
+    assert_equal('9s444ms', 9.444.seconds)
+
+    # Seconds (10-100s)
+    assert_equal('45s', 45.5.seconds(:round))
+
+    # Minutes and seconds
+    assert_equal('3m', 184.0.seconds(:round))
+    assert_equal('3m4s', 184.0.seconds)
+
+    # Hours and minutes
+    assert_equal('1h', 3661.0.seconds(:round))
+    assert_equal('1h1m', 3661.0.seconds)
+
+    # Days and hours
+    assert_equal('1d', 90_000.0.seconds(:round))
+    assert_equal('1d1h', 90_000.0.seconds)
+
+    # Weeks and days
+    assert_equal('1w', 691_200.0.seconds(:round))
+    assert_equal('1w1d', 691_200.0.seconds)
+
+    # Edge case: exact boundaries
+    assert_equal('1h', 3600.0.seconds(:round))
+    assert_equal('1d', 86_400.0.seconds(:round))
+    assert_equal('1w', 604_800.0.seconds(:round))
+  end
 end


### PR DESCRIPTION
Fixes #70

* Added `:round` option to return only the most significant unit
* Works for all time ranges (ms, seconds, minutes, hours, days, weeks)
* Added tests

Examples:
```ruby
9.444.seconds(:round)    # => "9s" (instead of "9s444ms")
3661.0.seconds(:round)   # => "1h" (instead of "1h1m")
90_000.0.seconds(:round) # => "1d" (instead of "1d1h")
```